### PR TITLE
Change BaseAgent::check() scope

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: tattersoftware
+custom: "https://paypal.me/tatter"

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
 		}
 	],
 	"require": {
-		"php": "^7.3|^8.0",
+		"php": "^7.3 || ^8.0",
 		"tatter/handlers": "^2.0",
 		"tatter/reports": "^1.1"
 	},
 	"require-dev": {
 		"codeigniter4/codeigniter4": "dev-develop",
-		"tatter/tools": "^1.4"
+		"tatter/tools": "^1.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-
-require 'vendor/codeigniter4/codeigniter4/app/Config/Paths.php';
-$paths = new Config\Paths();
-require_once 'vendor/codeigniter4/codeigniter4/system/bootstrap.php';

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,16 +5,19 @@ parameters:
 		- src
 		- tests
 	bootstrapFiles:
-		- phpstan-bootstrap.php
+		- vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php
 	excludes_analyse:
 		- src/Config/Routes.php
 		- src/Views/*
 	ignoreErrors:
 		- '#Cannot access property [\$a-z_]+ on (array|object)#'
 		- '#Unsafe usage of new static\(\)*#'
+	universalObjectCratesClasses:
+		- CodeIgniter\Entity
+		- Faker\Generator
 	scanDirectories:
 		- vendor/codeigniter4/codeigniter4/system/Helpers
 	dynamicConstantNames:
-		- ENVIRONMENT
-		- CI_DEBUG
 		- APP_NAMESPACE
+		- CI_DEBUG
+		- ENVIRONMENT

--- a/src/BaseAgent.php
+++ b/src/BaseAgent.php
@@ -28,7 +28,7 @@ abstract class BaseAgent extends Entity implements HandlerInterface
 	 *
 	 * @return void
 	 */
-	abstract protected function check(): void;
+	abstract public function check(): void;
 
 	/**
 	 * Sets an overriding batch ID to use.


### PR DESCRIPTION
Fixes a mistake in the `BaseAgent` class that defined a clearly public method as protected. All the examples and implementations were `public` and `protected` would not have worked so this will not receive a major release version.